### PR TITLE
Hide navigation on mobile

### DIFF
--- a/src/app/components/Sidebar/anticorruption_sidebar.tsx
+++ b/src/app/components/Sidebar/anticorruption_sidebar.tsx
@@ -20,6 +20,9 @@ import {
 import SidebarWrapper from '../sidebarWrapper/index';
 import {AnticorruptionAdmin} from '../../models/anticorruption';
 import {loadAnticorruptionAdminsConfig} from '../../redux/modules/institutions/anticorruption';
+import {DispatchProps} from "../Section/filters";
+import {openSidebar} from "../../redux/reducers";
+import {ResponsiveBrowser} from "../../models/responsiveBrowser";
 
 const style = require('./style.css');
 
@@ -28,6 +31,7 @@ interface Props {
   location?: MyLocation;
   anticorruptionAdmins?: OrderedMap<number, AnticorruptionAdmin>;
   areAnticorruptionAdminsLoaded?: boolean;
+  browser: ResponsiveBrowser;
 }
 
 @asyncConnect([
@@ -37,9 +41,25 @@ interface Props {
   (state: ApplicationState): Props => ({
     areAnticorruptionAdminsLoaded: areAnticorruptionAdminsLoaded(state),
     anticorruptionAdmins: anticorruptionAdmins(state),
+    browser: state.browser,
   }),
 )
-class AnticorruptionAdminsSidebar extends React.Component<Props, {}> {
+class AnticorruptionAdminsSidebar extends React.Component<Props & DispatchProps, {}> {
+  constructor(props) {
+    super(props);
+    this.closeSidebar = this.closeSidebar.bind(this);
+  }
+
+  private closeSidebar(event: any) {
+    const {browser} = this.props;
+    const smaller = (browser.lessThan.medium && browser.width !== browser.breakpoints.small);
+
+    if (smaller) {
+      event.preventDefault();
+      this.props.onAction(openSidebar(false));
+    }
+  }
+
   public render() {
     if (!this.props.areAnticorruptionAdminsLoaded) {
       return (<div>Se încarcă</div>);
@@ -50,6 +70,7 @@ class AnticorruptionAdminsSidebar extends React.Component<Props, {}> {
     const menus = this.props.anticorruptionAdmins.toIndexedSeq().map((i) => (
       <li key={`item-${i.id}`}>
         <Link to={ireportPath(indId, i.id, this.props.location.query)}
+              onClick={this.closeSidebar}
               activeStyle={{color: '#337ab7', textDecoration: 'none'}}>
           {i.name}
         </Link>

--- a/src/app/components/Sidebar/counties_sidebar.tsx
+++ b/src/app/components/Sidebar/counties_sidebar.tsx
@@ -26,6 +26,8 @@ import {
 } from '../../models/county';
 import {loadCountiesConfig} from '../../redux/modules/counties/index';
 import {loadCountyAdminsConfig} from '../../redux/modules/institutions/county';
+import {openSidebar} from "../../redux/reducers";
+import {DispatchProps} from "../Section/filters";
 
 const style = require('./style.css');
 
@@ -36,6 +38,7 @@ interface Props {
   countyAdmins?: OrderedMap<number, CountyAdmin>;
   areCountiesLoaded?: boolean;
   areCountyAdminsLoaded?: boolean;
+  browser;
 }
 
 @asyncConnect([
@@ -48,9 +51,25 @@ interface Props {
     counties: counties(state),
     areCountyAdminsLoaded: areCountyAdminsLoaded(state),
     countyAdmins: countyAdmins(state),
+    browser: state.browser,
   }),
 )
-class CountiesSidebar extends React.Component<Props, {}> {
+class CountiesSidebar extends React.Component<Props & DispatchProps, {}> {
+  constructor(props) {
+    super(props);
+    this.closeSidebar = this.closeSidebar.bind(this);
+  }
+
+  private closeSidebar(event: any) {
+    const {browser} = this.props;
+    const smaller = (browser.lessThan.medium && browser.width !== browser.breakpoints.small);
+
+    if (smaller) {
+      event.preventDefault();
+      this.props.onAction(openSidebar(false));
+    }
+  }
+
   public render() {
     if (!this.props.areCountiesLoaded) {
       return (<div>Se încarcă</div>);
@@ -58,9 +77,11 @@ class CountiesSidebar extends React.Component<Props, {}> {
 
     const indId = parseInt(this.props.params.id, 10);
 
-    const menus = this.props.counties.map((c) => (  // TODO replace counties with countyAdmins.toIndexedSeq().
+    // TODO replace counties with countyAdmins.toIndexedSeq().
+    const menus = this.props.counties.map((c) => (
       <li key={`item-${c.id}`}>
         <Link to={creportPath(indId, c.id, this.props.location.query)}
+              onClick={this.closeSidebar}
               activeStyle={{color: '#337ab7', textDecoration: 'none'}}>
           {c.name}
         </Link>

--- a/src/app/components/Sidebar/ministries_sidebar.tsx
+++ b/src/app/components/Sidebar/ministries_sidebar.tsx
@@ -20,6 +20,9 @@ import {
 import SidebarWrapper from '../sidebarWrapper/index';
 import {Ministry} from '../../models/ministry';
 import {loadMinistriesConfig} from '../../redux/modules/institutions/ministry';
+import {DispatchProps} from "../Section/filters";
+import {openSidebar} from "../../redux/reducers";
+import {ResponsiveBrowser} from "../../models/responsiveBrowser";
 
 const style = require('./style.css');
 
@@ -28,6 +31,7 @@ interface Props {
   location?: MyLocation;
   ministries?: OrderedMap<number, Ministry>;
   areMinistriesStatsLoaded?: boolean;
+  browser: ResponsiveBrowser;
 }
 
 @asyncConnect([
@@ -37,9 +41,25 @@ interface Props {
   (state: ApplicationState): Props => ({
     areMinistriesStatsLoaded: areMinistryStatsLoaded(state),
     ministries: ministryAdmins(state),
+    browser: state.browser,
   }),
 )
-class MinistriesSidebar extends React.Component<Props, {}> {
+class MinistriesSidebar extends React.Component<Props & DispatchProps, {}> {
+  constructor(props) {
+    super(props);
+    this.closeSidebar = this.closeSidebar.bind(this);
+  }
+
+  private closeSidebar(event: any) {
+    const {browser} = this.props;
+    const smaller = (browser.lessThan.medium && browser.width !== browser.breakpoints.small);
+
+    if (smaller) {
+      event.preventDefault();
+      this.props.onAction(openSidebar(false));
+    }
+  }
+
   public render() {
     if (!this.props.areMinistriesStatsLoaded) {
       return (<div>Se încarcă</div>);
@@ -50,6 +70,7 @@ class MinistriesSidebar extends React.Component<Props, {}> {
     const menus = this.props.ministries.toIndexedSeq().map((i) => (
       <li key={`item-${i.id}`}>
         <Link to={mreportPath(indId, i.id, this.props.location.query)}
+              onClick={this.closeSidebar}
               activeStyle={{color: '#337ab7', textDecoration: 'none'}}>
           {i.name}
         </Link>


### PR DESCRIPTION
When the user selects the institution for which he wants
to see the stats, we hide the navigation, because otherwise
it seems like the site isn't working.

Fixes #74.